### PR TITLE
Fixed various bugs

### DIFF
--- a/examples/generate_code.rs
+++ b/examples/generate_code.rs
@@ -377,7 +377,8 @@ fn uses(o: &Output, classes: bool) -> String {
 fn write_files(o: &Output, writers: &Writers, folder: &str, classes: bool) -> rome::Result<()> {
     let uses = uses(o, classes);
     let dir_path = o.output_dir.join(folder);
-    if !fs::metadata(&dir_path)?.is_dir() {
+    let metadata = fs::metadata(&dir_path);
+    if !fs::metadata(&dir_path).is_ok() || !metadata?.is_dir() {
         fs::create_dir(&dir_path)?;
     }
     let path = dir_path.join("mod.rs");

--- a/src/iter/transitive_iterator.rs
+++ b/src/iter/transitive_iterator.rs
@@ -39,11 +39,11 @@ impl<I, J, F> TransitiveIterator<I, J, F>
         for (pos, item) in self.iters.iter_mut().enumerate() {
             match (item.1.peek(), min) {
                 (Some(m), Some(n)) if m < n => {
-                    min_pos = Some(pos);
+                    min_pos = Some(pos + 1);
                     min = Some(m)
                 }
                 (Some(m), None) => {
-                    min_pos = Some(pos);
+                    min_pos = Some(pos + 1);
                     min = Some(m)
                 }
                 _ => {}

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -7,22 +7,27 @@ use ontology_adapter;
 use resource;
 use std;
 
+#[macro_export]
 macro_rules!
 rb{($p:ident) =>
     (<<Self as resource::ResourceBase<'g>>::Graph as graph::Graph<'g>>::$p)
 }
+#[macro_export]
 macro_rules!
 resource{() =>
     (graph::Resource<'g, rb!(BlankNodePtr), rb!(IRIPtr), rb!(LiteralPtr)>)
 }
+#[macro_export]
 macro_rules!
 adapter{() =>
     (ontology_adapter::OntologyAdapter<'g, Self::Graph>)
 }
+#[macro_export]
 macro_rules!
 g{($p:ident) =>
     (<G as graph::Graph<'g>>::$p)
 }
+#[macro_export]
 macro_rules!
 g_resource{() =>
     (graph::Resource<'g, g!(BlankNodePtr), g!(IRIPtr), g!(LiteralPtr)>)
@@ -347,7 +352,7 @@ impl<'g, G: 'g> resource::ResourceBase<'g> for $name<'g, G>
         }
     }
     fn iter(adapter: &'g adapter!()) -> resource::SubjectIter<'g, Self> {
-        use graph::IRIPtr;
+        use self::graph::IRIPtr;
         let rdf_type = adapter.preloaded_iri(0);
         let class = adapter.preloaded_iri($pos);
         let iter = match (rdf_type, class) {


### PR DESCRIPTION
While trying to use `rome` to generate Turtle parser code (for lv2 plugins), I fixed several issues:

* the output directories in `generate_code.rs` weren't created,
* `TransitiveIterator` wasn't working for transitive dependencies,
* some macros weren't exported, which made the generated code not compile in other crates,
* `graph::IRIPtr;` generated errors on compilation, replaced with `self::graph::IRIPtr`.

